### PR TITLE
chore: sync workflow references

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Merge PR
         run: |
-          gh pr merge --auto --squash --body="[ci skip]" "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
           gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NIO_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
- remove [ci skip] from automerge
- switch automerge to NIO_BOT_TOKEN